### PR TITLE
Add comments controller and comment policy

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,22 @@
+class CommentsController < ApplicationController
+  include Pundit::Authorization
+  before_action :authenticate_user!
+  before_action :comment, only: %i[show]
+
+  def index
+    @comments = Comment.all.order(created_at: :desc)
+    authorize @comments
+    render json: @comments
+  end
+
+  def show
+    authorize comment
+    render json: comment
+  end
+
+
+  private
+  def comment
+    @comment ||= Comment.find(params[:id])
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,21 +1,19 @@
 class CommentsController < ApplicationController
-  include Pundit::Authorization
   before_action :authenticate_user!
   before_action :comment, only: %i[show]
 
   def index
-    @comments = Comment.all.order(created_at: :desc)
-    authorize @comments
+    @comments = policy_scope(Comment).order(created_at: :desc)
     render json: @comments
   end
 
   def show
-    authorize comment
-    render json: comment
+    authorize @comment
+    render json: @comment
   end
 
-
   private
+
   def comment
     @comment ||= Comment.find(params[:id])
   end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,0 +1,15 @@
+class CommentPolicy < ApplicationPolicy
+  def show?
+    true
+  end
+
+  def index?
+    true
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :comments, only: [:show, :index]
   mount_devise_token_auth_for 'User', at: 'auth'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get comments_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get comments_show_url
+    assert_response :success
+  end
+end

--- a/test/policies/comment_policy_test.rb
+++ b/test/policies/comment_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class CommentPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Adicionado o comments controller com as ações index e show,  essas ações estão disponíveis publicamente, permitindo que qualquer usuário veja a lista de comentários e detalhes de um comentário específico.
