### PR TITLE
Add CommentSerializer and ApplicationSerializer

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,12 +4,12 @@ class CommentsController < ApplicationController
 
   def index
     @comments = policy_scope(Comment).order(created_at: :desc)
-    render json: @comments
+    render json: @comments.map { |comment| CommentSerializer.call(comment) }
   end
 
   def show
     authorize @comment
-    render json: @comment
+    render json: CommentSerializer.call(@comment)
   end
 
   private

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,8 @@
+class ApplicationSerializer
+  def self.serialize_timestamps(record)
+    {
+      created_at: record.respond_to?(:created_at) && record.created_at.present? ? record.created_at.strftime("%d/%m/%Y %H:%M") : nil,
+      updated_at: record.respond_to?(:updated_at) && record.updated_at.present? ? record.updated_at.strftime("%d/%m/%Y %H:%M") : nil
+    }
+  end
+end

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -9,4 +9,3 @@ class CommentSerializer < ApplicationSerializer
     base_data.merge(serialize_timestamps(comment))
     end
 end
-  

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,0 +1,12 @@
+class CommentSerializer < ApplicationSerializer
+ 
+    def self.call(comment)
+      base_data = {
+      content: comment.content,
+      user_name: comment.user&.name || "Anonymous"
+    }
+    
+    base_data.merge(serialize_timestamps(comment))
+    end
+end
+  


### PR DESCRIPTION
**Adicionar CommentSerializer e ApplicationSerializer**

- Implementado o ApplicationSerializer com o método serialize_timestamps, que verifica e formata os campos created_at e updated_at, retornando nil se não existirem.

- Criado o CommentSerializer, que serializa comentários, incluindo content e o nome do usuário, além de chamar o método de timestamps.