### PR TITLE
Add create and update to CommentsController

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pundit::Authorization
+
+  before_action :authenticate_user!,unless: :devise_controller?
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,6 +10,36 @@ class CommentsController < ApplicationController
     authorize @comment
     render json: CommentSerializer.call(@comment)
   end
+  
+  def create
+    @comment = Comment.new(permitted_attributes(Comment))
+
+    if params[:post_id]
+      @comment.commentable = Post.find(params[:post_id])
+    elsif params[:comment_id]
+      @comment.commentable = Comment.find(params[:comment_id])
+    else
+      return render json: { error: 'O comentário deve estar associado a uma postagem ou outro comentário'}, status: :unprocessable_entity
+    end
+
+    authorize @comment
+
+    if @comment.save
+      render json: CommentSerializer.call(@comment), status: :created
+    else
+      render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update 
+    authorize @comment
+
+    if @comment.update(permitted_attributes(Comment))
+      render json: CommentSerializer.call(@comment), status: :ok
+    else
+      render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
 
   private
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :comment, only: %i[show]
+  before_action :comment, only: %i[show update]
 
   def index
     @comments = policy_scope(Comment).order(created_at: :desc)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -14,6 +14,8 @@ class CommentsController < ApplicationController
   def create
     @comment = Comment.new(permitted_attributes(Comment))
 
+    @comment.user = current_user
+
     if params[:post_id]
       @comment.commentable = Post.find(params[:post_id])
     elsif params[:comment_id]

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,4 @@
 class CommentsController < ApplicationController
-  before_action :authenticate_user!
   before_action :comment, only: %i[show]
 
   def index

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -1,0 +1,22 @@
+class CompaniesController < ApplicationController
+
+  def index
+    @companies = policy_scope(Company)
+    render json: @companies
+  end
+
+  def show
+    authorize_company
+    render json: company
+  end
+
+  private
+
+  def company
+    @company ||= Company.find(params[:id])
+  end
+
+  def authorize_company
+    authorize company
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,19 @@
+class PostsController < ApplicationController
+  before_action :post, only: %i[show]
+
+  def index
+    @posts = policy_scope(Post).order(created_at: :desc)
+    render json: @posts
+  end
+
+  def show
+    authorize @post
+    render json: post
+  end
+
+  private
+
+  def post
+    @post ||= Post.find(params[:id])
+  end
+end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -7,6 +7,22 @@ class CommentPolicy < ApplicationPolicy
     true
   end
 
+  def create?
+    user.present? 
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    user.present? && (user == record.user)
+  end
+
+  def permitted_attributes
+      [:content, :commentable_id, :commentable_type, :user_id]
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.all

--- a/app/policies/company_policy.rb
+++ b/app/policies/company_policy.rb
@@ -1,0 +1,38 @@
+class CompanyPolicy < ApplicationPolicy
+  attr_reader :current_user, :company
+
+  def index?
+    current_user.admin?  
+  end
+
+  def show?
+    current_user.present? && current_user.admin?  
+  end
+
+  def create?
+    current_user.admin?  
+  end
+
+  def update?
+    current_user.admin?  
+  end
+
+  def destroy?
+    current_user.admin?  
+  end
+
+  class Scope < Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if @user&.admin? # Use safe navigation operator para evitar erro se @user for nil
+        @scope.all  
+      else
+        @scope.none  
+      end
+    end
+  end
+end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,0 +1,15 @@
+class PostPolicy < ApplicationPolicy
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,8 @@
 Rails.application.routes.draw do
-  resources :posts, only: [:index, :show]
-  resources :companies, only: [:index, :show] 
   resources :comments, only: [:show, :index]
   mount_devise_token_auth_for 'User', at: 'auth'
-  
-  resources :posts do
-    resources :comments, only: [:show, :index, :create, :update]
-  end
-  resources :comments do
-    resources :comments, only: [:show, :index, :create, :update]
-  end
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-
-  
   # Defines the root path route ("/")
   # root "articles#index"
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:show, :index, :create, :update]
   end
 
+
   
   # Defines the root path route ("/")
   # root "articles#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,17 @@
 Rails.application.routes.draw do
   resources :posts, only: [:index, :show]
+  resources :companies, only: [:index, :show] 
   resources :comments, only: [:show, :index]
   mount_devise_token_auth_for 'User', at: 'auth'
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  
+  resources :posts do
+    resources :comments, only: [:show, :index, :create, :update]
+  end
+  resources :comments do
+    resources :comments, only: [:show, :index, :create, :update]
+  end
 
-  resources :companies, only: [:index, :show] 
+  
   # Defines the root path route ("/")
   # root "articles#index"
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,17 @@
 Rails.application.routes.draw do
-  resources :comments, only: [:show, :index]
+  resources :posts, only: [:index, :show]
+  resources :companies, only: [:index, :show] 
   mount_devise_token_auth_for 'User', at: 'auth'
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  
+  resources :posts do
+    resources :comments, only: [:show, :index, :create, :update]
+  end
+  resources :comments do
+    resources :comments, only: [:show, :index, :create, :update]
+  end
 
+
+  
   # Defines the root path route ("/")
   # root "articles#index"
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'auth'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
+  resources :companies, only: [:index, :show] 
   # Defines the root path route ("/")
   # root "articles#index"
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
+  resources :posts, only: [:index, :show]
   resources :comments, only: [:show, :index]
   mount_devise_token_auth_for 'User', at: 'auth'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
   # root "articles#index"
-  # 
+  #
   # get 'users', to: 'users#index'
 end

--- a/test/controllers/companies_controller_test.rb
+++ b/test/controllers/companies_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CompaniesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get posts_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get posts_show_url
+    assert_response :success
+  end
+end

--- a/test/policies/company_policy_test.rb
+++ b/test/policies/company_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class CompanyPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/post_policy_test.rb
+++ b/test/policies/post_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class PostPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Adiciona as ações `create` e `update` ao `CommentsController` para permitir a criação e atualização de comentários. Também inclui verificação de autorização para garantir que apenas usuários autorizados possam realizar essas ações, com tratamento de erros apropriado caso o usuário não tenha permissão para atualizar um comentário de outro usuário.
