### PR TITLE
Add error messages for users, posts, domains, and companies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,14 @@
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
   include Pundit::Authorization
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   before_action :authenticate_user!,unless: :devise_controller?
+  
+  private
 
-  def handle_record_invalid(exception)
-    render json: { errors: exception.record.errors.full_messages }, status: :unprocessable_entity
+  def user_not_authorized(exception)
+    policy_name = exception.policy.class.to_s.underscore
+    render json: { error: I18n.t("errors.#{policy_name}.#{exception.query}") }, status: :forbidden
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ module AbaNetwork
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore
     # Configuration for the application, engines, and railties goes here.
+    config.i18n.default_locale = :'pt-BR'
     #
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,186 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   "true": "foo"
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+ # ACTIVERECORD
+activerecord:
+  errors:
+    models:
+      user:
+        attributes:
+          email:
+            blank: "can't be blank"
+            invalid: "is not a valid email address"
+            taken: "is already taken"
+          encrypted_password:
+            blank: "can't be blank"
+          name:
+            blank: "can't be blank"
+          role:
+            blank: "can't be blank"
+          admin:
+            blank: "can't be blank"
+          company_id:
+            blank: "can't be blank"
+      post:
+        attributes:
+          content:
+            blank: "can't be blank"
+          published:
+            blank: "can't be blank"
+      comment:
+        attributes:
+          content:
+            blank: "can't be blank"
+          user_id:
+            blank: "can't be blank"
+          commentable_id:
+            blank: "can't be blank"
+          commentable_type:
+            blank: "can't be blank"
+      company:
+        attributes:
+          name:
+            blank: "can't be blank"
+          cnpj:
+            blank: "can't be blank"
+            invalid: "is not a valid CNPJ"
+      domain:
+        attributes:
+          domain_url:
+            blank: "can't be blank"
+      company_domain:
+        attributes:
+          company_id:
+            blank: "can't be blank"
+          domain_id:
+            blank: "can't be blank"
+      attachment:
+        attributes:
+          record_type:
+            blank: "can't be blank"
+          record_id:
+            blank: "can't be blank"
+          post_id:
+            blank: "can't be blank"
+
+# COMMENTS
+comments:
+  index:
+    success: "Comments loaded successfully."
+  show:
+    success: "Comment loaded successfully."
+    not_found: "Comment not found."
+  create:
+    success: "Comment created successfully."
+    failure: "Failed to create the comment."
+  update:
+    success: "Comment updated successfully."
+    failure: "Failed to update the comment."
+  destroy:
+    success: "Comment deleted successfully."
+    failure: "Failed to delete the comment."
+  unauthorized: "You do not have permission to perform this action."
+
+  errors:
+    comment_policy:
+      create: "You must be authenticated to create a comment."
+      update: "You can only update your own comments."
+      destroy: "You can only delete your own comments."
+
+# USERS
+users:
+  index:
+    success: "Users loaded successfully."
+    failure: "Failed to load users."
+  show:
+    success: "User loaded successfully."
+    not_found: "User not found."
+  create:
+    success: "User created successfully."
+    failure: "Failed to create the user."
+  update:
+    success: "User updated successfully."
+    failure: "Failed to update the user."
+  destroy:
+    success: "User deleted successfully."
+    failure: "Failed to delete the user."
+  unauthorized: "You do not have permission to perform this action."
+  
+  errors:
+    user_policy:
+      create: "You must be authenticated to create a user."
+      update: "You can only update your own data."
+      destroy: "You can only delete your own account."
+
+# POSTS
+posts:
+  index:
+    success: "Posts loaded successfully."
+    failure: "Failed to load posts."
+  show:
+    success: "Post loaded successfully."
+    not_found: "Post not found."
+  create:
+    success: "Post created successfully."
+    failure: "Failed to create the post."
+  update:
+    success: "Post updated successfully."
+    failure: "Failed to update the post."
+  destroy:
+    success: "Post deleted successfully."
+    failure: "Failed to delete the post."
+  unauthorized: "You do not have permission to perform this action."
+  
+  errors:
+    post_policy:
+      create: "You must be authenticated to create a post."
+      update: "You can only update your own posts."
+      destroy: "You can only delete your own posts." 
+
+# DOMAINS
+domains:
+  index:
+    success: "Domains loaded successfully."
+    failure: "Failed to load domains."
+  show:
+    success: "Domain loaded successfully."
+    not_found: "Domain not found."
+  create:
+    success: "Domain created successfully."
+    failure: "Failed to create the domain."
+  update:
+    success: "Domain updated successfully."
+    failure: "Failed to update the domain."
+  destroy:
+    success: "Domain deleted successfully."
+    failure: "Failed to delete the domain."
+  unauthorized: "You do not have permission to perform this action."
+  
+  errors:
+    domain_policy:
+      create: "Only administrators can create domains."
+      update: "Only administrators can update domains."
+      destroy: "Only administrators can delete domains."
+
+# COMPANIES
+companies:
+  index:
+    success: "Companies loaded successfully."
+    failure: "Failed to load companies."
+  show:
+    success: "Company loaded successfully."
+    not_found: "Company not found."
+  create:
+    success: "Company created successfully."
+    failure: "Failed to create the company."
+  update:
+    success: "Company updated successfully."
+    failure: "Failed to update the company."
+  destroy:
+    success: "Company deleted successfully."
+    failure: "Failed to delete the company."
+  unauthorized: "You do not have permission to perform this action."
+  
+  errors:
+    company_policy:
+      create: "Only administrators can create companies."
+      update: "Only administrators can update companies."
+      destroy: "Only administrators can delete companies."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,250 @@
+pt-BR:
+#DEVISE
+  devise:
+    confirmations:
+      confirmed: "Seu endereço de e-mail foi confirmado com sucesso."
+      send_instructions: "Você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
+    failure:
+      already_authenticated: "Você já está autenticado."
+      inactive: "Sua conta ainda não está ativada."
+      invalid: "%{authentication_keys} ou senha inválidos."
+      locked: "Sua conta está bloqueada."
+      last_attempt: "Você tem mais uma tentativa antes que sua conta seja bloqueada."
+      not_found_in_database: "%{authentication_keys} ou senha inválidos."
+      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
+      unauthenticated: "Você precisa se autenticar ou se registrar antes de continuar."
+      unconfirmed: "Você precisa confirmar seu endereço de e-mail antes de continuar."
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+      reset_password_instructions:
+        subject: "Instruções para redefinir a senha"
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+      email_changed:
+        subject: "E-mail alterado"
+      password_change:
+        subject: "Senha alterada"
+    omniauth_callbacks:
+      failure: "Não foi possível autenticar você no %{kind} porque \"%{reason}\"."
+      success: "Autenticado com sucesso na conta %{kind}."
+    passwords:
+      no_token: "Você não pode acessar esta página sem vir de um e-mail de redefinição de senha. Se você veio de um e-mail de redefinição de senha, certifique-se de usar o URL completo fornecido."
+      send_instructions: "Você receberá um e-mail com instruções para redefinir sua senha em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um link para recuperação de senha em alguns minutos."
+      updated: "Sua senha foi alterada com sucesso. Você está autenticado agora."
+      updated_not_active: "Sua senha foi alterada com sucesso."
+    registrations:
+      destroyed: "Até logo! Sua conta foi cancelada com sucesso. Esperamos vê-lo novamente em breve."
+      signed_up: "Bem-vindo! Seu registro foi realizado com sucesso."
+      signed_up_but_inactive: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta ainda não está ativada."
+      signed_up_but_locked: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta está bloqueada."
+      signed_up_but_unconfirmed: "Uma mensagem com um link de confirmação foi enviada para o seu e-mail. Por favor, siga o link para ativar sua conta."
+      update_needs_confirmation: "Sua conta foi atualizada com sucesso, mas precisamos verificar seu novo endereço de e-mail. Por favor, verifique seu e-mail e siga o link de confirmação para confirmar seu novo endereço."
+      updated: "Sua conta foi atualizada com sucesso."
+      updated_but_not_signed_in: "Sua conta foi atualizada com sucesso, mas como sua senha foi alterada, você precisa fazer login novamente."
+    sessions:
+      signed_in: "Login realizado com sucesso."
+      signed_out: "Logout realizado com sucesso."
+      already_signed_out: "Logout realizado com sucesso."
+    unlocks:
+      send_instructions: "Você receberá um e-mail com instruções para desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, você receberá um e-mail com instruções para desbloqueá-la em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
+  errors:
+    messages:
+      already_confirmed: "já foi confirmado, por favor tente fazer login"
+      confirmation_period_expired: "precisa ser confirmado dentro de %{period}, por favor, solicite um novo"
+      expired: "expirou, por favor solicite um novo"
+      not_found: "não encontrado"
+      not_locked: "não estava bloqueado"
+      not_saved:
+        one: "1 erro impediu que este %{resource} fosse salvo:"
+        other: "%{count} erros impediram que este %{resource} fosse salvo:"
+
+#ACTIVERECORD
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "não pode ficar em branco"
+              invalid: "não é um endereço de e-mail válido"
+              taken: "já está em uso"
+            encrypted_password:
+              blank: "não pode ficar em branco"
+            name:
+              blank: "não pode ficar em branco"
+            role:
+              blank: "não pode ficar em branco"
+            admin:
+              blank: "não pode ficar em branco"
+            company_id:
+              blank: "não pode ficar em branco"
+        post:
+          attributes:
+            content:
+              blank: "não pode ficar em branco"
+            published:
+              blank: "não pode ficar em branco"
+        comment:
+          attributes:
+            content:
+              blank: "não pode ficar em branco"
+            user_id:
+              blank: "não pode ficar em branco"
+            commentable_id:
+              blank: "não pode ficar em branco"
+            commentable_type:
+              blank: "não pode ficar em branco"
+        company:
+          attributes:
+            name:
+              blank: "não pode ficar em branco"
+            cnpj:
+              blank: "não pode ficar em branco"
+              invalid: "não é um CNPJ válido"
+        domain:
+          attributes:
+            domain_url:
+              blank: "não pode ficar em branco"
+        company_domain:
+          attributes:
+            company_id:
+              blank: "não pode ficar em branco"
+            domain_id:
+              blank: "não pode ficar em branco"
+        attachment:
+          attributes:
+            record_type:
+              blank: "não pode ficar em branco"
+            record_id:
+              blank: "não pode ficar em branco"
+            post_id:
+              blank: "não pode ficar em branco"
+
+#COMMENTS
+  comments:
+    index:
+      success: "Comentários carregados com sucesso."
+    show:
+      success: "Comentário carregado com sucesso."
+      not_found: "Comentário não encontrado."
+    create:
+      success: "Comentário criado com sucesso."
+      failure: "Falha ao criar o comentário."
+    update:
+      success: "Comentário atualizado com sucesso."
+      failure: "Falha ao atualizar o comentário."
+    destroy:
+      success: "Comentário excluído com sucesso."
+      failure: "Falha ao excluir o comentário."
+    unauthorized: "Você não tem permissão para executar esta ação."
+
+    errors:
+      comment_policy:
+        create: "Você precisa estar autenticado para criar um comentário."
+        update: "Você só pode atualizar seus próprios comentários."
+        destroy: "Você só pode excluir seus próprios comentários."
+
+# USERS
+  users:
+    index:
+      success: "Usuários carregados com sucesso."
+      failure: "Falha ao carregar os usuários."
+    show:
+      success: "Usuário carregado com sucesso."
+      not_found: "Usuário não encontrado."
+    create:
+      success: "Usuário criado com sucesso."
+      failure: "Falha ao criar o usuário."
+    update:
+      success: "Usuário atualizado com sucesso."
+      failure: "Falha ao atualizar o usuário."
+    destroy:
+      success: "Usuário excluído com sucesso."
+      failure: "Falha ao excluir o usuário."
+    unauthorized: "Você não tem permissão para executar esta ação."
+    
+    errors:
+      user_policy:
+        create: "Você precisa estar autenticado para criar um usuário."
+        update: "Você só pode atualizar seus próprios dados."
+        destroy: "Você só pode excluir sua própria conta."
+
+# POSTS
+  posts:
+    index:
+      success: "Posts carregados com sucesso."
+      failure: "Falha ao carregar os posts."
+    show:
+      success: "Post carregado com sucesso."
+      not_found: "Post não encontrado."
+    create:
+      success: "Post criado com sucesso."
+      failure: "Falha ao criar o post."
+    update:
+      success: "Post atualizado com sucesso."
+      failure: "Falha ao atualizar o post."
+    destroy:
+      success: "Post excluído com sucesso."
+      failure: "Falha ao excluir o post."
+    unauthorized: "Você não tem permissão para executar esta ação."
+    
+    errors:
+      post_policy:
+        create: "Você precisa estar autenticado para criar um post."
+        update: "Você só pode atualizar seus próprios posts."
+        destroy: "Você só pode excluir seus próprios posts." 
+        
+# DOMAINS
+  domains:
+    index:
+      success: "Domínios carregados com sucesso."
+      failure: "Falha ao carregar os domínios."
+    show:
+      success: "Domínio carregado com sucesso."
+      not_found: "Domínio não encontrado."
+    create:
+      success: "Domínio criado com sucesso."
+      failure: "Falha ao criar o domínio."
+    update:
+      success: "Domínio atualizado com sucesso."
+      failure: "Falha ao atualizar o domínio."
+    destroy:
+      success: "Domínio excluído com sucesso."
+      failure: "Falha ao excluir o domínio."
+    unauthorized: "Você não tem permissão para executar esta ação."
+    
+    errors:
+      domain_policy:
+        create: "Apenas administradores podem criar domínios."
+        update: "Apenas administradores podem atualizar domínios."
+        destroy: "Apenas administradores podem excluir domínios."
+# COMPANIES
+  companies:
+    index:
+      success: "Empresas carregadas com sucesso."
+      failure: "Falha ao carregar as empresas."
+    show:
+      success: "Empresa carregada com sucesso."
+      not_found: "Empresa não encontrada."
+    create:
+      success: "Empresa criada com sucesso."
+      failure: "Falha ao criar a empresa."
+    update:
+      success: "Empresa atualizada com sucesso."
+      failure: "Falha ao atualizar a empresa."
+    destroy:
+      success: "Empresa excluída com sucesso."
+      failure: "Falha ao excluir a empresa."
+    unauthorized: "Você não tem permissão para executar esta ação."
+    
+    errors:
+      company_policy:
+        create: "Apenas administradores podem criar empresas."
+        update: "Apenas administradores podem atualizar empresas."
+        destroy: "Apenas administradores podem excluir empresas."
+        

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -247,4 +247,3 @@ pt-BR:
         create: "Apenas administradores podem criar empresas."
         update: "Apenas administradores podem atualizar empresas."
         destroy: "Apenas administradores podem excluir empresas."
-        


### PR DESCRIPTION
Este commit aprimora o suporte à internacionalização (i18n) com novas mensagens de erro e sucesso para os modelos de Usuário, Post, Domínio e Empresa.

- **Usuários:** Mensagens de feedback para todas as operações CRUD e erros de validação.
- **Posts:** Mensagens claras de sucesso e falha, incluindo validações de conteúdo.
- **Domínios:** Mensagens para operações de gerenciamento e validações de URLs.
- **Empresas:** Atualizadas mensagens de feedback e validações para campos essenciais.
- **Autorização:** Mensagens de erro detalhadas para ações permitidas.

Essas melhorias visam oferecer uma experiência mais clara e intuitiva para os usuários.
