### PR TITLE
Bugfix/fix i18n

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::API
 
   def user_not_authorized(exception)
     policy_name = exception.policy.class.to_s.underscore
-    message = I18n.t("errors.#{policy_name}.#{exception.query}", default: "Você não tem permissão para realizar esta ação.")
+    message = I18n.t("errors.#{policy_name}.#{exception.query}")
     render json: { error: message }, status: :forbidden
   end  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,8 +12,11 @@ class ApplicationController < ActionController::API
   private
 
   def user_not_authorized(exception)
-    policy_name = exception.policy.class.to_s.underscore
-    message = I18n.t("errors.#{policy_name}.#{exception.query}")
+    policy_name = exception.policy.class.to_s.underscore.gsub('_policy', '')
+    action = exception.query.to_s.chomp('?')
+    resource_scope = policy_name.pluralize
+    translation_key = "#{resource_scope}.errors.#{policy_name}_policy.#{action}"
+    message = I18n.t(translation_key)
     render json: { error: message }, status: :forbidden
-  end  
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,6 +32,7 @@ class CommentsController < ApplicationController
   def destroy
     authorize comment
     comment.destroy!
+    head :no_content
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,7 +32,6 @@ class CommentsController < ApplicationController
   def destroy
     authorize comment
     comment.destroy!
-    render_deletion_message('Comment')
   end
 
   private

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,10 @@ default: &default
   adapter: postgresql
   encoding: unicode
 
+  username: aba_network
+  password: 1345
+  host: localhost
+  port: 5433
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-
-  username: aba_network
-  password: 1345
-  host: localhost
-  port: 5433
+  
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,11 +2,6 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  
-  username: aba_network
-  password: 1345
-  host: localhost
-  port: 5433
 
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,11 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  
+  username: aba_network
+  password: 1345
+  host: localhost
+  port: 5433
 
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -1,0 +1,64 @@
+pt-BR:
+#DEVISE
+  devise:
+    confirmations:
+      confirmed: "Seu endereço de e-mail foi confirmado com sucesso."
+      send_instructions: "Você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
+    failure:
+      already_authenticated: "Você já está autenticado."
+      inactive: "Sua conta ainda não está ativada."
+      invalid: "%{authentication_keys} ou senha inválidos."
+      locked: "Sua conta está bloqueada."
+      last_attempt: "Você tem mais uma tentativa antes que sua conta seja bloqueada."
+      not_found_in_database: "%{authentication_keys} ou senha inválidos."
+      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
+      unauthenticated: "Você precisa se autenticar ou se registrar antes de continuar."
+      unconfirmed: "Você precisa confirmar seu endereço de e-mail antes de continuar."
+    mailer:
+      confirmation_instructions:
+        subject: "Instruções de confirmação"
+      reset_password_instructions:
+        subject: "Instruções para redefinir a senha"
+      unlock_instructions:
+        subject: "Instruções de desbloqueio"
+      email_changed:
+        subject: "E-mail alterado"
+      password_change:
+        subject: "Senha alterada"
+    omniauth_callbacks:
+      failure: "Não foi possível autenticar você no %{kind} porque \"%{reason}\"."
+      success: "Autenticado com sucesso na conta %{kind}."
+    passwords:
+      no_token: "Você não pode acessar esta página sem vir de um e-mail de redefinição de senha. Se você veio de um e-mail de redefinição de senha, certifique-se de usar o URL completo fornecido."
+      send_instructions: "Você receberá um e-mail com instruções para redefinir sua senha em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um link para recuperação de senha em alguns minutos."
+      updated: "Sua senha foi alterada com sucesso. Você está autenticado agora."
+      updated_not_active: "Sua senha foi alterada com sucesso."
+    registrations:
+      destroyed: "Até logo! Sua conta foi cancelada com sucesso. Esperamos vê-lo novamente em breve."
+      signed_up: "Bem-vindo! Seu registro foi realizado com sucesso."
+      signed_up_but_inactive: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta ainda não está ativada."
+      signed_up_but_locked: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta está bloqueada."
+      signed_up_but_unconfirmed: "Uma mensagem com um link de confirmação foi enviada para o seu e-mail. Por favor, siga o link para ativar sua conta."
+      update_needs_confirmation: "Sua conta foi atualizada com sucesso, mas precisamos verificar seu novo endereço de e-mail. Por favor, verifique seu e-mail e siga o link de confirmação para confirmar seu novo endereço."
+      updated: "Sua conta foi atualizada com sucesso."
+      updated_but_not_signed_in: "Sua conta foi atualizada com sucesso, mas como sua senha foi alterada, você precisa fazer login novamente."
+    sessions:
+      signed_in: "Login realizado com sucesso."
+      signed_out: "Logout realizado com sucesso."
+      already_signed_out: "Logout realizado com sucesso."
+    unlocks:
+      send_instructions: "Você receberá um e-mail com instruções para desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, você receberá um e-mail com instruções para desbloqueá-la em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
+  errors:
+    messages:
+      already_confirmed: "já foi confirmado, por favor tente fazer login"
+      confirmation_period_expired: "precisa ser confirmado dentro de %{period}, por favor, solicite um novo"
+      expired: "expirou, por favor solicite um novo"
+      not_found: "não encontrado"
+      not_locked: "não estava bloqueado"
+      not_saved:
+        one: "1 erro impediu que este %{resource} fosse salvo:"
+        other: "%{count} erros impediram que este %{resource} fosse salvo:"

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -1,5 +1,4 @@
 pt-BR:
-#DEVISE
   devise:
     confirmations:
       confirmed: "Seu endereço de e-mail foi confirmado com sucesso."

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -62,3 +62,4 @@ pt-BR:
       not_saved:
         one: "1 erro impediu que este %{resource} fosse salvo:"
         other: "%{count} erros impediram que este %{resource} fosse salvo:"
+        

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -62,4 +62,3 @@ pt-BR:
       not_saved:
         one: "1 erro impediu que este %{resource} fosse salvo:"
         other: "%{count} erros impediram que este %{resource} fosse salvo:"
-        

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,4 @@
-en:
- # ACTIVERECORD
+#ACTIVERECORD
 activerecord:
   errors:
     models:
@@ -61,7 +60,7 @@ activerecord:
           post_id:
             blank: "can't be blank"
 
-# COMMENTS
+#COMMENTS
 comments:
   index:
     success: "Comments loaded successfully."
@@ -78,10 +77,15 @@ comments:
     success: "Comment deleted successfully."
     failure: "Failed to delete the comment."
   unauthorized: "You do not have permission to perform this action."
-
   errors:
+    create:
+      failure: "Failed to create the comment."
+    update:
+      failure: "Failed to update the comment."
+    destroy:
+      failure: "Failed to delete the comment."
     comment_policy:
-      create: "You must be authenticated to create a comment."
+      create: "You need to be authenticated to create a comment."
       update: "You can only update your own comments."
       destroy: "You can only delete your own comments."
 
@@ -106,7 +110,7 @@ users:
   
   errors:
     user_policy:
-      create: "You must be authenticated to create a user."
+      create: "You need to be authenticated to create a user."
       update: "You can only update your own data."
       destroy: "You can only delete your own account."
 
@@ -128,12 +132,17 @@ posts:
     success: "Post deleted successfully."
     failure: "Failed to delete the post."
   unauthorized: "You do not have permission to perform this action."
-  
   errors:
+    create:
+      failure: "Failed to create the post."
+    update:
+      failure: "Failed to update the post."
+    destroy:
+      failure: "Failed to delete the post."
     post_policy:
-      create: "You must be authenticated to create a post."
+      create: "You need to be authenticated to create a post."
       update: "You can only update your own posts."
-      destroy: "You can only delete your own posts." 
+      destroy: "You can only delete your own posts."
 
 # DOMAINS
 domains:
@@ -153,8 +162,13 @@ domains:
     success: "Domain deleted successfully."
     failure: "Failed to delete the domain."
   unauthorized: "You do not have permission to perform this action."
-  
   errors:
+    create:
+      failure: "Failed to create the domain."
+    update:
+      failure: "Failed to update the domain."
+    destroy:
+      failure: "Failed to delete the domain."
     domain_policy:
       create: "Only administrators can create domains."
       update: "Only administrators can update domains."
@@ -178,9 +192,29 @@ companies:
     success: "Company deleted successfully."
     failure: "Failed to delete the company."
   unauthorized: "You do not have permission to perform this action."
-  
   errors:
+    create:
+      failure: "Failed to create the company."
+    update:
+      failure: "Failed to update the company."
+    destroy:
+      failure: "Failed to delete the company."
     company_policy:
       create: "Only administrators can create companies."
       update: "Only administrators can update companies."
       destroy: "Only administrators can delete companies."
+
+# ATTACHMENTS
+attachments:
+  create:
+    success: "Attachment created successfully."
+    failure: "Failed to create the attachment."
+  destroy:
+    success: "Attachment deleted successfully."
+    failure: "Failed to delete the attachment."
+  unauthorized: "You do not have permission to perform this action."
+  errors:
+    create:
+      failure: "Failed to create the attachment."
+    destroy:
+      failure: "Failed to delete the attachment."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -11,8 +11,12 @@ pt-BR:
               taken: "já está em uso"
             encrypted_password:
               blank: "não pode ficar em branco"
+            password:
+              blank: "não pode ficar em branco"
+              too_short: "é muito curto (mínimo de %{count} caracteres)"
             name:
               blank: "não pode ficar em branco"
+              too_short: "é muito curto (mínimo de %{count} caracteres)"
             role:
               blank: "não pode ficar em branco"
             admin:
@@ -25,12 +29,17 @@ pt-BR:
               blank: "não pode ficar em branco"
             published:
               blank: "não pode ficar em branco"
+              inclusion: "deve ser verdadeiro ou falso"
         comment:
           attributes:
             content:
               blank: "não pode ficar em branco"
-            user_id:
+            user:
               blank: "não pode ficar em branco"
+              required: "é obrigatório"
+            commentable:
+              blank: "não pode ficar em branco"
+              required: "é obrigatório"
             commentable_id:
               blank: "não pode ficar em branco"
             commentable_type:
@@ -39,13 +48,16 @@ pt-BR:
           attributes:
             name:
               blank: "não pode ficar em branco"
+              too_short: "é muito curto (mínimo de %{count} caracteres)"
             cnpj:
               blank: "não pode ficar em branco"
               invalid: "não é um CNPJ válido"
+              wrong_length: "deve ter exatamente %{count} caracteres"
         domain:
           attributes:
             domain_url:
               blank: "não pode ficar em branco"
+              invalid: "não é um URL válido"
         company_domain:
           attributes:
             company_id:
@@ -60,6 +72,15 @@ pt-BR:
               blank: "não pode ficar em branco"
             post_id:
               blank: "não pode ficar em branco"
+      messages:
+        blank: "não pode ficar em branco"
+        too_short: "é muito curto (mínimo de %{count} caracteres)"
+        invalid: "não é válido"
+        taken: "já está em uso"
+        wrong_length: "deve ter exatamente %{count} caracteres"
+        required: "é obrigatório"
+        inclusion: "deve ser um valor válido"
+
 
 #COMMENTS
   comments:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -219,4 +219,3 @@ pt-BR:
         failure: "Falha ao criar o anexo."
       destroy:
         failure: "Falha ao excluir o anexo."
-        

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,68 +1,4 @@
 pt-BR:
-#DEVISE
-  devise:
-    confirmations:
-      confirmed: "Seu endereço de e-mail foi confirmado com sucesso."
-      send_instructions: "Você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
-      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um e-mail com instruções para confirmar seu endereço de e-mail em alguns minutos."
-    failure:
-      already_authenticated: "Você já está autenticado."
-      inactive: "Sua conta ainda não está ativada."
-      invalid: "%{authentication_keys} ou senha inválidos."
-      locked: "Sua conta está bloqueada."
-      last_attempt: "Você tem mais uma tentativa antes que sua conta seja bloqueada."
-      not_found_in_database: "%{authentication_keys} ou senha inválidos."
-      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
-      unauthenticated: "Você precisa se autenticar ou se registrar antes de continuar."
-      unconfirmed: "Você precisa confirmar seu endereço de e-mail antes de continuar."
-    mailer:
-      confirmation_instructions:
-        subject: "Instruções de confirmação"
-      reset_password_instructions:
-        subject: "Instruções para redefinir a senha"
-      unlock_instructions:
-        subject: "Instruções de desbloqueio"
-      email_changed:
-        subject: "E-mail alterado"
-      password_change:
-        subject: "Senha alterada"
-    omniauth_callbacks:
-      failure: "Não foi possível autenticar você no %{kind} porque \"%{reason}\"."
-      success: "Autenticado com sucesso na conta %{kind}."
-    passwords:
-      no_token: "Você não pode acessar esta página sem vir de um e-mail de redefinição de senha. Se você veio de um e-mail de redefinição de senha, certifique-se de usar o URL completo fornecido."
-      send_instructions: "Você receberá um e-mail com instruções para redefinir sua senha em alguns minutos."
-      send_paranoid_instructions: "Se seu endereço de e-mail estiver em nosso banco de dados, você receberá um link para recuperação de senha em alguns minutos."
-      updated: "Sua senha foi alterada com sucesso. Você está autenticado agora."
-      updated_not_active: "Sua senha foi alterada com sucesso."
-    registrations:
-      destroyed: "Até logo! Sua conta foi cancelada com sucesso. Esperamos vê-lo novamente em breve."
-      signed_up: "Bem-vindo! Seu registro foi realizado com sucesso."
-      signed_up_but_inactive: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta ainda não está ativada."
-      signed_up_but_locked: "Você se registrou com sucesso. No entanto, não foi possível autenticá-lo porque sua conta está bloqueada."
-      signed_up_but_unconfirmed: "Uma mensagem com um link de confirmação foi enviada para o seu e-mail. Por favor, siga o link para ativar sua conta."
-      update_needs_confirmation: "Sua conta foi atualizada com sucesso, mas precisamos verificar seu novo endereço de e-mail. Por favor, verifique seu e-mail e siga o link de confirmação para confirmar seu novo endereço."
-      updated: "Sua conta foi atualizada com sucesso."
-      updated_but_not_signed_in: "Sua conta foi atualizada com sucesso, mas como sua senha foi alterada, você precisa fazer login novamente."
-    sessions:
-      signed_in: "Login realizado com sucesso."
-      signed_out: "Logout realizado com sucesso."
-      already_signed_out: "Logout realizado com sucesso."
-    unlocks:
-      send_instructions: "Você receberá um e-mail com instruções para desbloquear sua conta em alguns minutos."
-      send_paranoid_instructions: "Se sua conta existir, você receberá um e-mail com instruções para desbloqueá-la em alguns minutos."
-      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
-  errors:
-    messages:
-      already_confirmed: "já foi confirmado, por favor tente fazer login"
-      confirmation_period_expired: "precisa ser confirmado dentro de %{period}, por favor, solicite um novo"
-      expired: "expirou, por favor solicite um novo"
-      not_found: "não encontrado"
-      not_locked: "não estava bloqueado"
-      not_saved:
-        one: "1 erro impediu que este %{resource} fosse salvo:"
-        other: "%{count} erros impediram que este %{resource} fosse salvo:"
-
 #ACTIVERECORD
   activerecord:
     errors:
@@ -142,12 +78,17 @@ pt-BR:
       success: "Comentário excluído com sucesso."
       failure: "Falha ao excluir o comentário."
     unauthorized: "Você não tem permissão para executar esta ação."
-
     errors:
+      create:
+        failure: "Falha ao criar o comentário."
+      update:
+        failure: "Falha ao atualizar o comentário."
+      destroy:
+        failure: "Falha ao excluir o comentário."
       comment_policy:
-        create?: "Você precisa estar autenticado para criar um comentário."
-        update?: "Você só pode atualizar seus próprios comentários."
-        destroy?: "Você só pode excluir seus próprios comentários."
+        create: "Você precisa estar autenticado para criar um comentário."
+        update: "Você só pode atualizar seus próprios comentários."
+        destroy: "Você só pode excluir seus próprios comentários."      
 
 # USERS
   users:
@@ -192,13 +133,18 @@ pt-BR:
       success: "Post excluído com sucesso."
       failure: "Falha ao excluir o post."
     unauthorized: "Você não tem permissão para executar esta ação."
-    
     errors:
+      create:
+        failure: "Falha ao criar o post."
+      update:
+        failure: "Falha ao atualizar o post."
+      destroy:
+        failure: "Falha ao excluir o post."
       post_policy:
         create: "Você precisa estar autenticado para criar um post."
         update: "Você só pode atualizar seus próprios posts."
-        destroy: "Você só pode excluir seus próprios posts." 
-        
+        destroy: "Você só pode excluir seus próprios posts."
+
 # DOMAINS
   domains:
     index:
@@ -217,12 +163,18 @@ pt-BR:
       success: "Domínio excluído com sucesso."
       failure: "Falha ao excluir o domínio."
     unauthorized: "Você não tem permissão para executar esta ação."
-    
     errors:
+      create:
+        failure: "Falha ao criar o domínio."
+      update:
+        failure: "Falha ao atualizar o domínio."
+      destroy:
+        failure: "Falha ao excluir o domínio."
       domain_policy:
         create: "Apenas administradores podem criar domínios."
         update: "Apenas administradores podem atualizar domínios."
         destroy: "Apenas administradores podem excluir domínios."
+
 # COMPANIES
   companies:
     index:
@@ -241,9 +193,29 @@ pt-BR:
       success: "Empresa excluída com sucesso."
       failure: "Falha ao excluir a empresa."
     unauthorized: "Você não tem permissão para executar esta ação."
-    
     errors:
+      create:
+        failure: "Falha ao criar a empresa."
+      update:
+        failure: "Falha ao atualizar a empresa."
+      destroy:
+        failure: "Falha ao excluir a empresa."
       company_policy:
         create: "Apenas administradores podem criar empresas."
         update: "Apenas administradores podem atualizar empresas."
         destroy: "Apenas administradores podem excluir empresas."
+
+# ATTACHMENTS
+  attachments:
+    create:
+      success: "Anexo criado com sucesso."
+      failure: "Falha ao criar o anexo."
+    destroy:
+      success: "Anexo excluído com sucesso."
+      failure: "Falha ao excluir o anexo."
+    unauthorized: "Você não tem permissão para executar esta ação."
+    errors:
+      create:
+        failure: "Falha ao criar o anexo."
+      destroy:
+        failure: "Falha ao excluir o anexo."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -219,3 +219,4 @@ pt-BR:
         failure: "Falha ao criar o anexo."
       destroy:
         failure: "Falha ao excluir o anexo."
+        

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -80,6 +80,7 @@ pt-BR:
         wrong_length: "deve ter exatamente %{count} caracteres"
         required: "é obrigatório"
         inclusion: "deve ser um valor válido"
+        record_invalid: "Registro inválido. Verifique os campos obrigatórios ou as validações." 
 
 
 #COMMENTS

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,4 @@
 pt-BR:
-#ACTIVERECORD
   activerecord:
     errors:
       models:
@@ -82,8 +81,6 @@ pt-BR:
         inclusion: "deve ser um valor válido"
         record_invalid: "Registro inválido. Verifique os campos obrigatórios ou as validações." 
 
-
-#COMMENTS
   comments:
     index:
       success: "Comentários carregados com sucesso."
@@ -112,7 +109,6 @@ pt-BR:
         update: "Você só pode atualizar seus próprios comentários."
         destroy: "Você só pode excluir seus próprios comentários."      
 
-# USERS
   users:
     index:
       success: "Usuários carregados com sucesso."
@@ -137,7 +133,6 @@ pt-BR:
         update: "Você só pode atualizar seus próprios dados."
         destroy: "Você só pode excluir sua própria conta."
 
-# POSTS
   posts:
     index:
       success: "Posts carregados com sucesso."
@@ -167,7 +162,6 @@ pt-BR:
         update: "Você só pode atualizar seus próprios posts."
         destroy: "Você só pode excluir seus próprios posts."
 
-# DOMAINS
   domains:
     index:
       success: "Domínios carregados com sucesso."
@@ -197,7 +191,6 @@ pt-BR:
         update: "Apenas administradores podem atualizar domínios."
         destroy: "Apenas administradores podem excluir domínios."
 
-# COMPANIES
   companies:
     index:
       success: "Empresas carregadas com sucesso."
@@ -227,7 +220,6 @@ pt-BR:
         update: "Apenas administradores podem atualizar empresas."
         destroy: "Apenas administradores podem excluir empresas."
 
-# ATTACHMENTS
   attachments:
     create:
       success: "Anexo criado com sucesso."


### PR DESCRIPTION
Este PR introduz melhorias na gestão de autorizações, mensagens de erro e internacionalização (I18n) para melhor suporte multilíngue, além de ajustes gerais em controllers e configurações da aplicação. Ele visa garantir mensagens mais claras e consistentes para usuários finais e desenvolvedores.

 Mudanças Principais:

1. Atualizações no Controller:

- Adicionado tratamento centralizado de erros de autorização no método user_not_authorized.

- Implementado suporte a mensagens de erro mais específicas utilizando o I18n com chaves hierárquicas baseadas no escopo de política e ação.

2. Adição e Atualização de Arquivos de Localização (I18n):

- Criação de novos arquivos para mensagens Devise em português do Brasil (devise.pt-BR.yml), incluindo traduções detalhadas para mensagens de autenticação, registro e recuperação de senha.

- Revisão dos arquivos en.yml e pt-BR.yml para melhorar consistência, remover duplicatas e padronizar chaves de erro específicas por recurso e política.

3. Melhorias nas Mensagens de Erro por Recurso:

- Comments, Posts, Domains, Companies, Attachments: Mensagens de sucesso e erro personalizadas foram adicionadas em ambos os idiomas (pt-BR e en).

- Erros de autorização e validação agora estão claramente definidos com base na ação (e.g., create, update, destroy) e na política correspondente (e.g., comment_policy, post_policy).